### PR TITLE
feat: Add window_resize_listener widget

### DIFF
--- a/lib/src/internal/window_resize_listener.dart
+++ b/lib/src/internal/window_resize_listener.dart
@@ -21,6 +21,8 @@ class _WindowResizeListenerState extends State<WindowResizeListener>
     _lastSize = WidgetsBinding.instance!.window.physicalSize;
     WidgetsBinding.instance!.addObserver(this);
 
+    widget.onResize(_lastSize);
+
     super.initState();
   }
 

--- a/lib/src/internal/window_resize_listener.dart
+++ b/lib/src/internal/window_resize_listener.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class WindowResizeListener extends StatefulWidget {
+  final Function(Size size) onResize;
+  final Widget child;
+
+  const WindowResizeListener(
+      {Key? key, required this.onResize, required this.child})
+      : super(key: key);
+
+  @override
+  _WindowResizeListenerState createState() => _WindowResizeListenerState();
+}
+
+class _WindowResizeListenerState extends State<WindowResizeListener>
+    with WidgetsBindingObserver {
+  late Size _lastSize;
+
+  @override
+  void initState() {
+    _lastSize = WidgetsBinding.instance!.window.physicalSize;
+    WidgetsBinding.instance!.addObserver(this);
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance!.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    var winSize = WidgetsBinding.instance!.window.physicalSize;
+
+    if (winSize != _lastSize) {
+      widget.onResize(winSize);
+      _lastSize = winSize;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/src/widgets/flap.dart
+++ b/lib/src/widgets/flap.dart
@@ -117,7 +117,7 @@ class _AdwFlapState extends State<AdwFlap> {
           // affected by window resizes.
           // If FoldPolicy is auto, then close / open the sidebar depending on the
           // state
-          var isMobile = MediaQuery.of(context).size.width < widget.breakpoint;
+          var isMobile = size.width < widget.breakpoint;
           _controller.updateModalState(context, isMobile);
 
           switch (widget.foldPolicy) {

--- a/lib/src/widgets/flap.dart
+++ b/lib/src/widgets/flap.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:libadwaita/src/animations/slide_hide.dart';
 import 'package:libadwaita/src/controllers/flap_controller.dart';
-import 'package:libadwaita/src/internal/resize_listener.dart';
+import 'package:libadwaita/src/internal/window_resize_listener.dart';
 import 'package:libadwaita/src/utils/colors.dart';
 
 enum FoldPolicy { never, always, auto }


### PR DESCRIPTION
Useful for flap / leaflet and maybe other stuff in the future

The widget is rebuilt on every resize but there is no way to tell if it
was caused by a window resize or some other state change. This way we
can only update the needed parts on a window resize.