### PR TITLE
Improve `AdwHeaderButton` widget

### DIFF
--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:libadwaita/src/utils/colors.dart';
 
+enum ButtonStatus { normal, hover, tapDown }
+
 class AdwHeaderButton extends StatefulWidget {
   /// The icon of the button, use size of 17 for better results
   final Widget icon;
@@ -23,38 +25,65 @@ class AdwHeaderButton extends StatefulWidget {
 }
 
 class _AdwHeaderButtonState extends State<AdwHeaderButton> {
-  bool hovering = false;
+  var status = ButtonStatus.normal;
+
+  Color? _resolveColor() {
+    if (Theme.of(context).brightness == Brightness.dark) {
+      if (widget.isActive) {
+        return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
+      }
+
+      switch (status) {
+        case ButtonStatus.hover:
+          return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
+        case ButtonStatus.tapDown:
+          return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.20);
+        default:
+          return null;
+      }
+    } else {
+      if (widget.isActive) {
+        return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
+      }
+
+      switch (status) {
+        case ButtonStatus.hover:
+          return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
+        case ButtonStatus.tapDown:
+          return Theme.of(context).appBarTheme.backgroundColor?.darken(0.20);
+        default:
+          return null;
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    bool isDarkMode = Theme.of(context).brightness == Brightness.dark;
-    return InkWell(
-      onTap: widget.onPressed,
-      onHover: (hover) {
-        setState(() => hovering = hover);
-      },
-      child: AnimatedContainer(
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => status = ButtonStatus.hover),
+      onExit: (_) => setState(() => status = ButtonStatus.normal),
+      child: GestureDetector(
+        onTap: widget.onPressed,
+        onTapDown: (_) => setState(() => status = ButtonStatus.tapDown),
+        onTapUp: (_) => setState(() => status = ButtonStatus.hover),
+        child: AnimatedContainer(
           height: 34,
-          width: 36,
+          width: 34,
           duration: const Duration(milliseconds: 200),
           curve: Curves.ease,
           decoration: BoxDecoration(
             borderRadius: const BorderRadius.all(
               Radius.circular(8.0),
             ),
-            color: hovering
-                ? isDarkMode
-                    ? Theme.of(context)
-                        .appBarTheme
-                        .backgroundColor
-                        ?.lighten(0.03)
-                    : Theme.of(context)
-                        .appBarTheme
-                        .backgroundColor
-                        ?.darken(0.05)
-                : null,
+            color: _resolveColor(),
           ),
-          child: widget.icon),
+          child: IconTheme.merge(
+            data: Theme.of(context).iconTheme.copyWith(size: 17),
+            child: widget.icon,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -4,10 +4,10 @@ import 'package:libadwaita/src/utils/colors.dart';
 enum ButtonStatus { normal, hover, tapDown }
 
 class AdwHeaderButton extends StatefulWidget {
-  /// The icon of the button, use size of 17 for better results
+  /// The icon of the button. Default size would be `17`.
   final Widget icon;
 
-  /// Is this button active, generally it is for popup buttons
+  /// Controls the active status, generally used for popup buttons.
   final bool isActive;
 
   /// Triggered when the button is pressed.


### PR DESCRIPTION
This is PR I want to heavily improve the implementation of button and other intractable elements of the UI. Before this, the package was relying on Material specific visuals that were difficult to customize. I'm planning to open an issue explaining how we can brought the system implemented in the rework of this button to other parts of the app.

Main changes:

- Add a new system of handling user interaction with the button with the `ButtonStatus` enum. This way, is a bit easier to handle how the style changes according to the status.
- Fix 'active' state of the `AdwHeaderButton`.
- Set the width of the button to `34`. I've check in various designs that the button now is a perfect 34px square. Please let me know if I'm wrong here.
- Made the default size of the child icon to `17`, so you don't have to manually set it up down the widget tree.
- Remove use of `InkWell` in favor of `MouseRegion` + `GestureDetector`. If you see `InkWell`'s implementation, you'll see a similar pattern.