### PR TITLE
Add `AdwAvatar` widget

### DIFF
--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:bitsdojo_window/bitsdojo_window.dart';
+import 'package:example/pages/avatar_page.dart';
 import 'package:example/pages/counter_page.dart';
 import 'package:example/pages/flap_page.dart';
 import 'package:example/pages/lists_page.dart';
@@ -114,6 +115,9 @@ class _MyHomePageState extends State<MyHomePage> {
                     label: 'Lists',
                   ),
                   AdwSidebarItem(
+                    label: 'Avatar',
+                  ),
+                  AdwSidebarItem(
                     label: 'Flap',
                   ),
                   AdwSidebarItem(
@@ -149,6 +153,9 @@ class _MyHomePageState extends State<MyHomePage> {
                     label: 'Lists',
                   ),
                   AdwSidebarItem(
+                    label: 'Avatar',
+                  ),
+                  AdwSidebarItem(
                     label: 'Flap',
                   ),
                   AdwSidebarItem(
@@ -170,6 +177,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   const WelcomePage(),
                   CounterPage(counter: counter),
                   const ListsPage(),
+                  const AvatarPage(),
                   const FlapPage(),
                   const ViewSwitcherPage(),
                   const SettingsPage(),

--- a/example/lib/pages/avatar_page.dart
+++ b/example/lib/pages/avatar_page.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:libadwaita/libadwaita.dart';
+
+class AvatarPage extends StatelessWidget {
+  const AvatarPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return AdwClamp.scrollable(
+      center: true,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const AdwAvatar(
+            child: Icon(Icons.person),
+            size: 128,
+          ),
+          AdwPreferencesGroup(
+            title: 'All colors',
+            children: [
+              for (var index
+                  in List.generate(AdwAvatarColors.values.length, (i) => i))
+                AdwActionRow(
+                  start: AdwAvatar(
+                    backgroundColor: AdwAvatarColors.values[index],
+                    child: Text(index.toString()),
+                  ),
+                  title: 'Johnny Appleseed',
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -2,6 +2,8 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+/// This enum represents all possible color combinations a `AdwAvatar` widget
+/// can feature. They're extracted directly from the GTK `libadwaita` implementation.
 enum AdwAvatarColors {
   blue,
   cyan,
@@ -19,6 +21,8 @@ enum AdwAvatarColors {
   gray
 }
 
+/// Represents a set of background gradient colors and a foreground color for the
+/// `AdwAvatar` widget.
 class AdwAvatarColor {
   final Color foregroundColor;
   final List<Color> backgroundGradient;
@@ -29,6 +33,7 @@ class AdwAvatarColor {
   });
 }
 
+/// Color palette for both the foreground and background of a `AdwAvatar` widget.
 class AdwAvatarColorPalette {
   static const _palette = {
     AdwAvatarColors.blue: AdwAvatarColor(
@@ -131,6 +136,9 @@ class AdwAvatarColorPalette {
     ),
   };
 
+  /// Retunrs a set of values depending on the `color` variable.
+  ///
+  /// If the variable is `null`, it'll then return a random set of colors.
   static AdwAvatarColor getColor(AdwAvatarColors? color) {
     if (color != null) return _palette[color]!;
 
@@ -141,6 +149,9 @@ class AdwAvatarColorPalette {
   }
 }
 
+/// `AdwAvatar` is a widget that shows a round avatar. Usually, an icon or some
+/// letters. Automatic theme will be applied in those cases to make them look
+/// cohesive inside the avatar.
 class AdwAvatar extends StatelessWidget {
   const AdwAvatar({
     Key? key,
@@ -149,10 +160,16 @@ class AdwAvatar extends StatelessWidget {
     this.backgroundColor,
   }) : super(key: key);
 
+  /// Main view that will be rendered at the center of the avatar.
+  /// It will feature a default icon size of `size / 2`.
   final Widget child;
 
+  /// Size of the widget. Defaults to `40`.
   final double size;
 
+  /// Main color that will be used to decorate the widget.
+  ///
+  /// If `null`, a random set of colors will be picked.
   final AdwAvatarColors? backgroundColor;
 
   @override

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -177,7 +177,7 @@ class AdwAvatar extends StatelessWidget {
     assert(text.isNotEmpty, 'Text should not be empty');
 
     // 1. Trim the string from leading and trailing whitespace.
-    // 2. Separate the string via whitespaces (can be multiple spaces between words)
+    // 2. Separate the string via whitespaces (can be multiple spaces between words).
     // 3. Select a max of 2 words and store it in a list.
     final words = text.trim().split(RegExp(r' +')).take(2);
 

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -153,13 +153,48 @@ class AdwAvatarColorPalette {
 /// letters. Automatic theme will be applied in those cases to make them look
 /// cohesive inside the avatar.
 class AdwAvatar extends StatelessWidget {
+  static const defaultAvatarSize = 40.0;
+
   const AdwAvatar({
     Key? key,
     required this.child,
-    this.size = 40,
+    this.size = defaultAvatarSize,
     this.backgroundColor,
     this.backgroundImage,
   }) : super(key: key);
+
+  /// Constructor that allows the pass of a `String` object in order to render
+  /// the first letters of the first two words inside the widget.
+  ///
+  /// The `String` object should not be empty.
+  factory AdwAvatar.text({
+    Key? key,
+    required String text,
+    double size = defaultAvatarSize,
+    AdwAvatarColors? backgroundColor,
+    ImageProvider? backgroundImage,
+  }) {
+    assert(text.isNotEmpty, 'Text should not be empty');
+
+    // 1. Trim the string from leading and trailing whitespace.
+    // 2. Separate the string via whitespaces (can be multiple spaces between words)
+    // 3. Select a max of 2 words and store it in a list.
+    final words = text.trim().split(RegExp(r' +')).take(2);
+
+    // Pick the first letters of the words stored and join them in a string.
+    final letters = words.fold(
+      '',
+      (value, element) => '$value${element[0]}',
+    );
+
+    return AdwAvatar(
+      key: key,
+      child: Text(letters.toUpperCase()),
+      size: size,
+      backgroundColor: backgroundColor,
+      backgroundImage: backgroundImage,
+    );
+  }
 
   /// Main view that will be rendered at the center of the avatar.
   /// It will feature a default icon size of `size / 2`.

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -136,7 +136,7 @@ class AdwAvatarColorPalette {
     ),
   };
 
-  /// Retunrs a set of values depending on the `color` variable.
+  /// Returns a set of values depending on the `color` variable.
   ///
   /// If the variable is `null`, it'll then return a random set of colors.
   static AdwAvatarColor getColor(AdwAvatarColors? color) {

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -158,6 +158,7 @@ class AdwAvatar extends StatelessWidget {
     required this.child,
     this.size = 40,
     this.backgroundColor,
+    this.backgroundImage,
   }) : super(key: key);
 
   /// Main view that will be rendered at the center of the avatar.
@@ -172,6 +173,11 @@ class AdwAvatar extends StatelessWidget {
   /// If `null`, a random set of colors will be picked.
   final AdwAvatarColors? backgroundColor;
 
+  /// Image that will be rendered at the background of the widget.
+  ///
+  /// No background color or child will be visible is an image is provided.
+  final ImageProvider? backgroundImage;
+
   @override
   Widget build(BuildContext context) {
     final colorPalette = AdwAvatarColorPalette.getColor(backgroundColor);
@@ -181,25 +187,33 @@ class AdwAvatar extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           shape: BoxShape.circle,
+          image: backgroundImage != null
+              ? DecorationImage(
+                  image: backgroundImage!,
+                  fit: BoxFit.cover,
+                )
+              : null,
           gradient: LinearGradient(
             colors: colorPalette.backgroundGradient,
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
           ),
         ),
-        child: IconTheme.merge(
-          data: IconThemeData(
-            color: colorPalette.foregroundColor,
-            size: size / 2,
-          ),
-          child: DefaultTextStyle.merge(
-            style: TextStyle(
-              color: colorPalette.foregroundColor,
-              fontWeight: FontWeight.bold,
-            ),
-            child: Center(child: child),
-          ),
-        ),
+        child: backgroundImage == null
+            ? IconTheme.merge(
+                data: IconThemeData(
+                  color: colorPalette.foregroundColor,
+                  size: size / 2,
+                ),
+                child: DefaultTextStyle.merge(
+                  style: TextStyle(
+                    color: colorPalette.foregroundColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  child: Center(child: child),
+                ),
+              )
+            : null,
       ),
     );
   }

--- a/lib/src/widgets/adw/avatar.dart
+++ b/lib/src/widgets/adw/avatar.dart
@@ -1,0 +1,189 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+enum AdwAvatarColors {
+  blue,
+  cyan,
+  green,
+  lime,
+  yellow,
+  gold,
+  orange,
+  raspberry,
+  magenta,
+  purple,
+  violet,
+  beige,
+  brown,
+  gray
+}
+
+class AdwAvatarColor {
+  final Color foregroundColor;
+  final List<Color> backgroundGradient;
+
+  const AdwAvatarColor({
+    required this.foregroundColor,
+    required this.backgroundGradient,
+  });
+}
+
+class AdwAvatarColorPalette {
+  static const _palette = {
+    AdwAvatarColors.blue: AdwAvatarColor(
+      foregroundColor: Color(0xFFcfe1f5),
+      backgroundGradient: [
+        Color(0xFF83b6ec),
+        Color(0xFF337fdc),
+      ],
+    ),
+    AdwAvatarColors.cyan: AdwAvatarColor(
+      foregroundColor: Color(0xFFcaeaf2),
+      backgroundGradient: [
+        Color(0xFF7ad9f1),
+        Color(0xFF0f9ac8),
+      ],
+    ),
+    AdwAvatarColors.green: AdwAvatarColor(
+      foregroundColor: Color(0xFFcef8d8),
+      backgroundGradient: [
+        Color(0xFF8de6b1),
+        Color(0xFF29ae74),
+      ],
+    ),
+    AdwAvatarColors.lime: AdwAvatarColor(
+      foregroundColor: Color(0xFFe6f9d7),
+      backgroundGradient: [
+        Color(0xFFb5e98a),
+        Color(0xFF6ab85b),
+      ],
+    ),
+    AdwAvatarColors.yellow: AdwAvatarColor(
+      foregroundColor: Color(0xFFf9f4e1),
+      backgroundGradient: [
+        Color(0xFFf8e359),
+        Color(0xFFd29d09),
+      ],
+    ),
+    AdwAvatarColors.gold: AdwAvatarColor(
+      foregroundColor: Color(0xFFffead1),
+      backgroundGradient: [
+        Color(0xFFffcb62),
+        Color(0xFFd68400),
+      ],
+    ),
+    AdwAvatarColors.orange: AdwAvatarColor(
+      foregroundColor: Color(0xFFffe5c5),
+      backgroundGradient: [
+        Color(0xFFffa95a),
+        Color(0xFFed5b00),
+      ],
+    ),
+    AdwAvatarColors.raspberry: AdwAvatarColor(
+      foregroundColor: Color(0xFFf8d2ce),
+      backgroundGradient: [
+        Color(0xFFf78773),
+        Color(0xFFe62d42),
+      ],
+    ),
+    AdwAvatarColors.magenta: AdwAvatarColor(
+      foregroundColor: Color(0xFFfac7de),
+      backgroundGradient: [
+        Color(0xFFe973ab),
+        Color(0xFFe33b6a),
+      ],
+    ),
+    AdwAvatarColors.purple: AdwAvatarColor(
+      foregroundColor: Color(0xFFe7c2e8),
+      backgroundGradient: [
+        Color(0xFFcb78d4),
+        Color(0xFF9945b5),
+      ],
+    ),
+    AdwAvatarColors.violet: AdwAvatarColor(
+      foregroundColor: Color(0xFFd5d2f5),
+      backgroundGradient: [
+        Color(0xFF9e91e8),
+        Color(0xFF7a59ca),
+      ],
+    ),
+    AdwAvatarColors.beige: AdwAvatarColor(
+      foregroundColor: Color(0xFFf2eade),
+      backgroundGradient: [
+        Color(0xFFe3cf9c),
+        Color(0xFFb08952),
+      ],
+    ),
+    AdwAvatarColors.brown: AdwAvatarColor(
+      foregroundColor: Color(0xFFe5d6ca),
+      backgroundGradient: [
+        Color(0xFFbe916d),
+        Color(0xFF785336),
+      ],
+    ),
+    AdwAvatarColors.gray: AdwAvatarColor(
+      foregroundColor: Color(0xFFd8d7d3),
+      backgroundGradient: [
+        Color(0xFFc0bfbc),
+        Color(0xFF6e6d71),
+      ],
+    ),
+  };
+
+  static AdwAvatarColor getColor(AdwAvatarColors? color) {
+    if (color != null) return _palette[color]!;
+
+    final randomColor =
+        AdwAvatarColors.values[Random().nextInt(AdwAvatarColors.values.length)];
+
+    return _palette[randomColor]!;
+  }
+}
+
+class AdwAvatar extends StatelessWidget {
+  const AdwAvatar({
+    Key? key,
+    required this.child,
+    this.size = 40,
+    this.backgroundColor,
+  }) : super(key: key);
+
+  final Widget child;
+
+  final double size;
+
+  final AdwAvatarColors? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorPalette = AdwAvatarColorPalette.getColor(backgroundColor);
+    return SizedBox(
+      width: size,
+      height: size,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: LinearGradient(
+            colors: colorPalette.backgroundGradient,
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: IconTheme.merge(
+          data: IconThemeData(
+            color: colorPalette.foregroundColor,
+            size: size / 2,
+          ),
+          child: DefaultTextStyle.merge(
+            style: TextStyle(
+              color: colorPalette.foregroundColor,
+              fontWeight: FontWeight.bold,
+            ),
+            child: Center(child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -1,5 +1,6 @@
 // All the widgets imported from libadwaita
 export 'adw/action_row.dart';
+export 'adw/avatar.dart';
 export 'adw/combo_row.dart';
 export 'adw/clamp.dart';
 export 'adw/flap.dart';


### PR DESCRIPTION
Closes #32 

This PR introduces the `AdwAvatar` widget. Its use varies a bit compared to the GTK counterpart. In this implementation, the widgets accepts a `Widget` object as its child. I think this makes more sense within the Flutter world, compare to what the widgets receives in GTK: a string where the widgets picks the first two letters.

Let me know what you think about my decision to implements this widget the way I did.

An example page has also been introduced to show how this widgets works.

![image](https://user-images.githubusercontent.com/8961959/147823513-c1e5f398-1e35-458c-b03e-2e2947ac7d4e.png)
