### PR TITLE
Introduce `AdwButton` widget

### DIFF
--- a/lib/src/widgets/adw/button.dart
+++ b/lib/src/widgets/adw/button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Set of status that a [AdwButton] widget can be at any given time.
-enum AdwButtonStatus { enabled, active, hover, tapDown }
+enum AdwButtonStatus { enabled, active, enabledHovered, activeHovered, tapDown }
 
 typedef AdwButtonColorBuilder = Color? Function(BuildContext, AdwButtonStatus);
 
@@ -118,15 +118,25 @@ class _AdwButtonState extends State<AdwButton> {
   @override
   void didUpdateWidget(covariant AdwButton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _status =
-        widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled;
+    if (_status == AdwButtonStatus.tapDown) {
+      _status = widget.isActive
+          ? AdwButtonStatus.activeHovered
+          : AdwButtonStatus.enabledHovered;
+    } else {
+      _status =
+          widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _status = AdwButtonStatus.hover),
+      onEnter: (_) => setState(
+        () => _status = widget.isActive
+            ? AdwButtonStatus.activeHovered
+            : AdwButtonStatus.enabledHovered,
+      ),
       onExit: (_) => setState(
         () => _status =
             widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled,
@@ -134,11 +144,6 @@ class _AdwButtonState extends State<AdwButton> {
       child: GestureDetector(
         onTap: widget.onPressed,
         onTapDown: (_) => setState(() => _status = AdwButtonStatus.tapDown),
-        onTapUp: (_) => setState(
-          () => _status = widget.isActive
-              ? AdwButtonStatus.active
-              : AdwButtonStatus.enabled,
-        ),
         child: AnimatedContainer(
           padding: widget.padding,
           constraints: widget.constraints,

--- a/lib/src/widgets/adw/button.dart
+++ b/lib/src/widgets/adw/button.dart
@@ -1,19 +1,19 @@
 import 'package:flutter/material.dart';
 
-/// Set of status that a [RawAdwTarget] widget can be at any given time.
-enum TargetStatus { enabled, active, hover, tapDown }
+/// Set of status that a [AdwButton] widget can be at any given time.
+enum AdwButtonStatus { enabled, active, hover, tapDown }
 
-typedef TargetColorBuilder = Color? Function(BuildContext, TargetStatus);
+typedef AdwButtonColorBuilder = Color? Function(BuildContext, AdwButtonStatus);
 
-typedef TargetWidgetBuilder = Widget Function(BuildContext, TargetStatus);
+typedef AdwButtonWidgetBuilder = Widget Function(BuildContext, AdwButtonStatus);
 
-/// [RawAdwTarget] is a widget used as a base to build Adwaita-style widgets
+/// [AdwButton] is a widget used as a base to build Adwaita-style widgets
 /// with pressed and hover properties.
 ///
-/// Widgets that use [RawAdwTarget] as their base can rebuild
+/// Widgets that use [AdwButton] as their base can rebuild
 /// their background through the [backgroundColorBuilder] callback.
-class RawAdwTarget extends StatefulWidget {
-  const RawAdwTarget({
+class AdwButton extends StatefulWidget {
+  const AdwButton({
     Key? key,
     this.padding = EdgeInsets.zero,
     required this.builder,
@@ -36,14 +36,14 @@ class RawAdwTarget extends StatefulWidget {
   final EdgeInsets padding;
 
   /// Builder function used to create the child widget inside
-  /// the target widget.
-  final TargetWidgetBuilder builder;
+  /// the button widget.
+  final AdwButtonWidgetBuilder builder;
 
   /// Action to perform when the widget is tapped.
   final VoidCallback? onPressed;
 
-  /// Builder function used to create the background color of the target widget.
-  final TargetColorBuilder? backgroundColorBuilder;
+  /// Builder function used to create the background color of the button widget.
+  final AdwButtonColorBuilder? backgroundColorBuilder;
 
   /// Additional constraints to apply to the child.
   ///
@@ -102,39 +102,42 @@ class RawAdwTarget extends StatefulWidget {
   final bool isActive;
 
   @override
-  State<StatefulWidget> createState() => _RawAdwTargetState();
+  State<StatefulWidget> createState() => _AdwButtonState();
 }
 
-class _RawAdwTargetState extends State<RawAdwTarget> {
-  late TargetStatus _status;
+class _AdwButtonState extends State<AdwButton> {
+  late AdwButtonStatus _status;
 
   @override
   void initState() {
     super.initState();
-    _status = widget.isActive ? TargetStatus.active : TargetStatus.enabled;
+    _status =
+        widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled;
   }
 
   @override
-  void didUpdateWidget(covariant RawAdwTarget oldWidget) {
+  void didUpdateWidget(covariant AdwButton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _status = widget.isActive ? TargetStatus.active : TargetStatus.enabled;
+    _status =
+        widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled;
   }
 
   @override
   Widget build(BuildContext context) {
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _status = TargetStatus.hover),
+      onEnter: (_) => setState(() => _status = AdwButtonStatus.hover),
       onExit: (_) => setState(
         () => _status =
-            widget.isActive ? TargetStatus.active : TargetStatus.enabled,
+            widget.isActive ? AdwButtonStatus.active : AdwButtonStatus.enabled,
       ),
       child: GestureDetector(
         onTap: widget.onPressed,
-        onTapDown: (_) => setState(() => _status = TargetStatus.tapDown),
+        onTapDown: (_) => setState(() => _status = AdwButtonStatus.tapDown),
         onTapUp: (_) => setState(
-          () => _status =
-              widget.isActive ? TargetStatus.active : TargetStatus.enabled,
+          () => _status = widget.isActive
+              ? AdwButtonStatus.active
+              : AdwButtonStatus.enabled,
         ),
         child: AnimatedContainer(
           padding: widget.padding,

--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:libadwaita/libadwaita.dart';
 
+/// Button that is usually placed inside an `AdwHeaderBar` widget.
+///
+/// Via the `icon` parameter, a widget can be placed inside the button.
 class AdwHeaderButton extends StatelessWidget {
   /// The icon of the button. Default size would be `17`.
   final Widget icon;

--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -24,9 +24,11 @@ class AdwHeaderButton extends StatelessWidget {
   Color? _resolveBackgroundColor(BuildContext context, AdwButtonStatus status) {
     if (Theme.of(context).brightness == Brightness.dark) {
       switch (status) {
-        case AdwButtonStatus.hover:
+        case AdwButtonStatus.enabledHovered:
         case AdwButtonStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
+        case AdwButtonStatus.activeHovered:
+          return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.10);
         case AdwButtonStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.20);
         default:
@@ -34,9 +36,11 @@ class AdwHeaderButton extends StatelessWidget {
       }
     } else {
       switch (status) {
-        case AdwButtonStatus.hover:
+        case AdwButtonStatus.enabledHovered:
         case AdwButtonStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
+        case AdwButtonStatus.activeHovered:
+          return Theme.of(context).appBarTheme.backgroundColor?.darken(0.10);
         case AdwButtonStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.20);
         default:

--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -21,23 +21,23 @@ class AdwHeaderButton extends StatelessWidget {
     this.onPressed,
   }) : super(key: key);
 
-  Color? _resolveBackgroundColor(BuildContext context, TargetStatus status) {
+  Color? _resolveBackgroundColor(BuildContext context, AdwButtonStatus status) {
     if (Theme.of(context).brightness == Brightness.dark) {
       switch (status) {
-        case TargetStatus.hover:
-        case TargetStatus.active:
+        case AdwButtonStatus.hover:
+        case AdwButtonStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
-        case TargetStatus.tapDown:
+        case AdwButtonStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.20);
         default:
           return null;
       }
     } else {
       switch (status) {
-        case TargetStatus.hover:
-        case TargetStatus.active:
+        case AdwButtonStatus.hover:
+        case AdwButtonStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
-        case TargetStatus.tapDown:
+        case AdwButtonStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.20);
         default:
           return null;
@@ -47,7 +47,7 @@ class AdwHeaderButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RawAdwTarget(
+    return AdwButton(
       constraints: BoxConstraints.tight(const Size.square(34)),
       backgroundColorBuilder: _resolveBackgroundColor,
       onPressed: onPressed,

--- a/lib/src/widgets/adw/new/header_button.dart
+++ b/lib/src/widgets/adw/new/header_button.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:libadwaita/src/utils/colors.dart';
+import 'package:libadwaita/libadwaita.dart';
 
-enum ButtonStatus { normal, hover, tapDown }
-
-class AdwHeaderButton extends StatefulWidget {
+class AdwHeaderButton extends StatelessWidget {
   /// The icon of the button. Default size would be `17`.
   final Widget icon;
 
@@ -20,36 +18,23 @@ class AdwHeaderButton extends StatefulWidget {
     this.onPressed,
   }) : super(key: key);
 
-  @override
-  _AdwHeaderButtonState createState() => _AdwHeaderButtonState();
-}
-
-class _AdwHeaderButtonState extends State<AdwHeaderButton> {
-  var status = ButtonStatus.normal;
-
-  Color? _resolveColor() {
+  Color? _resolveBackgroundColor(BuildContext context, TargetStatus status) {
     if (Theme.of(context).brightness == Brightness.dark) {
-      if (widget.isActive) {
-        return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
-      }
-
       switch (status) {
-        case ButtonStatus.hover:
+        case TargetStatus.hover:
+        case TargetStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.03);
-        case ButtonStatus.tapDown:
+        case TargetStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.lighten(0.20);
         default:
           return null;
       }
     } else {
-      if (widget.isActive) {
-        return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
-      }
-
       switch (status) {
-        case ButtonStatus.hover:
+        case TargetStatus.hover:
+        case TargetStatus.active:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.05);
-        case ButtonStatus.tapDown:
+        case TargetStatus.tapDown:
           return Theme.of(context).appBarTheme.backgroundColor?.darken(0.20);
         default:
           return null;
@@ -59,30 +44,14 @@ class _AdwHeaderButtonState extends State<AdwHeaderButton> {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => status = ButtonStatus.hover),
-      onExit: (_) => setState(() => status = ButtonStatus.normal),
-      child: GestureDetector(
-        onTap: widget.onPressed,
-        onTapDown: (_) => setState(() => status = ButtonStatus.tapDown),
-        onTapUp: (_) => setState(() => status = ButtonStatus.hover),
-        child: AnimatedContainer(
-          height: 34,
-          width: 34,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.ease,
-          decoration: BoxDecoration(
-            borderRadius: const BorderRadius.all(
-              Radius.circular(8.0),
-            ),
-            color: _resolveColor(),
-          ),
-          child: IconTheme.merge(
-            data: Theme.of(context).iconTheme.copyWith(size: 17),
-            child: widget.icon,
-          ),
-        ),
+    return RawAdwTarget(
+      constraints: BoxConstraints.tight(const Size.square(34)),
+      backgroundColorBuilder: _resolveBackgroundColor,
+      onPressed: onPressed,
+      isActive: isActive,
+      builder: (context, status) => IconTheme.merge(
+        data: const IconThemeData(size: 17),
+        child: icon,
       ),
     );
   }

--- a/lib/src/widgets/adw/raw_target.dart
+++ b/lib/src/widgets/adw/raw_target.dart
@@ -7,18 +7,18 @@ typedef TargetColorBuilder = Color? Function(BuildContext, TargetStatus);
 
 typedef TargetWidgetBuilder = Widget Function(BuildContext, TargetStatus);
 
-/// Basic widget that can be used to create other more complex and customized
-/// buttons and other set of 'target' views.
+/// [RawAdwTarget] is a widget used as a base to build Adwaita-style widgets
+/// with pressed and hover properties.
 ///
-/// It offers the ability to reconstruct sets of properties depending on the
-/// current state of the view.
+/// Widgets that use [RawAdwTarget] as their base can rebuild
+/// their background through the [backgroundColorBuilder] callback.
 class RawAdwTarget extends StatefulWidget {
   const RawAdwTarget({
     Key? key,
     this.padding = EdgeInsets.zero,
     required this.builder,
     this.onPressed,
-    required this.backgroundColorBuilder,
+    this.backgroundColorBuilder,
     this.constraints,
     this.borderRadius = const BorderRadius.all(
       Radius.circular(8.0),
@@ -43,7 +43,7 @@ class RawAdwTarget extends StatefulWidget {
   final VoidCallback? onPressed;
 
   /// Builder function used to create the background color of the target widget.
-  final TargetColorBuilder backgroundColorBuilder;
+  final TargetColorBuilder? backgroundColorBuilder;
 
   /// Additional constraints to apply to the child.
   ///
@@ -146,7 +146,7 @@ class _RawAdwTargetState extends State<RawAdwTarget> {
             shape: widget.shape,
             boxShadow: widget.boxShadow,
             borderRadius: widget.borderRadius,
-            color: widget.backgroundColorBuilder(context, _status),
+            color: widget.backgroundColorBuilder?.call(context, _status),
           ),
           child: widget.builder(context, _status),
         ),

--- a/lib/src/widgets/adw/raw_target.dart
+++ b/lib/src/widgets/adw/raw_target.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
 
+/// Set of status that a [RawAdwTarget] widget can be at any given time.
 enum TargetStatus { enabled, active, hover, tapDown }
 
-typedef ColorBuilder = Color? Function(BuildContext, TargetStatus);
+typedef TargetColorBuilder = Color? Function(BuildContext, TargetStatus);
 
 typedef TargetWidgetBuilder = Widget Function(BuildContext, TargetStatus);
 
+/// Basic widget that can be used to create other more complex and customized
+/// buttons and other set of 'target' views.
+///
+/// It offers the ability to reconstruct sets of properties depending on the
+/// current state of the view.
 class RawAdwTarget extends StatefulWidget {
   const RawAdwTarget({
     Key? key,
@@ -19,31 +25,80 @@ class RawAdwTarget extends StatefulWidget {
     ),
     this.border,
     this.shape = BoxShape.rectangle,
+    this.boxShadow,
     this.animationDuration = const Duration(milliseconds: 200),
     this.animationCurve = Curves.ease,
     this.isActive = false,
   }) : super(key: key);
 
+  /// Empty space to inscribe inside the [decoration]. The [child], if any, is
+  /// placed inside this padding.
   final EdgeInsets padding;
 
+  /// Builder function used to create the child widget inside
+  /// the target widget.
   final TargetWidgetBuilder builder;
 
+  /// Action to perform when the widget is tapped.
   final VoidCallback? onPressed;
 
-  final ColorBuilder backgroundColorBuilder;
+  /// Builder function used to create the background color of the target widget.
+  final TargetColorBuilder backgroundColorBuilder;
 
+  /// Additional constraints to apply to the child.
+  ///
+  /// The [padding] goes inside the constraints.
   final BoxConstraints? constraints;
 
+  /// If non-null, the corners of this box are rounded by this [BorderRadius].
+  ///
+  /// Applies only to boxes with rectangular shapes; ignored if [shape] is not
+  /// [BoxShape.rectangle].
+  ///
+  /// {@macro flutter.painting.BoxDecoration.clip}
   final BorderRadius borderRadius;
 
+  /// A border to draw above the background [color].
+  ///
+  /// Follows the [shape] and [borderRadius].
+  ///
+  /// Use [Border] objects to describe borders that do not depend on the reading
+  /// direction.
+  ///
+  /// Use [BoxBorder] objects to describe borders that should flip their left
+  /// and right edges based on whether the text is being read left-to-right or
+  /// right-to-left.
+  ///
   final BoxBorder? border;
 
+  /// The shape to fill the background [color] into and
+  /// to cast as the [boxShadow].
+  ///
+  /// If this is [BoxShape.circle] then [borderRadius] is ignored.
+  ///
+  /// The [shape] cannot be interpolated; animating between two [BoxDecoration]s
+  /// with different [shape]s will result in a discontinuity in the rendering.
+  /// To interpolate between two shapes, consider using [ShapeDecoration] and
+  /// different [ShapeBorder]s; in particular, [CircleBorder] instead of
+  /// [BoxShape.circle] and [RoundedRectangleBorder] instead of
+  /// [BoxShape.rectangle].
+  ///
+  /// {@macro flutter.painting.BoxDecoration.clip}
   final BoxShape shape;
 
+  /// A list of shadows cast by this box behind the box.
+  ///
+  /// The shadow follows the [shape] of the box.
+  final List<BoxShadow>? boxShadow;
+
+  /// The duration over which to animate the parameters of this container.
   final Duration animationDuration;
 
+  /// The curve to apply when animating the parameters of this container.
   final Curve animationCurve;
 
+  /// Status flag to denote that the widget is active.
+  /// Usually for popup buttons.
   final bool isActive;
 
   @override
@@ -89,6 +144,7 @@ class _RawAdwTargetState extends State<RawAdwTarget> {
           decoration: BoxDecoration(
             border: widget.border,
             shape: widget.shape,
+            boxShadow: widget.boxShadow,
             borderRadius: widget.borderRadius,
             color: widget.backgroundColorBuilder(context, _status),
           ),

--- a/lib/src/widgets/adw/raw_target.dart
+++ b/lib/src/widgets/adw/raw_target.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+
+enum TargetStatus { enabled, active, hover, tapDown }
+
+typedef ColorBuilder = Color? Function(BuildContext, TargetStatus);
+
+typedef TargetWidgetBuilder = Widget Function(BuildContext, TargetStatus);
+
+class RawAdwTarget extends StatefulWidget {
+  const RawAdwTarget({
+    Key? key,
+    this.padding = EdgeInsets.zero,
+    required this.builder,
+    this.onPressed,
+    required this.backgroundColorBuilder,
+    this.constraints,
+    this.borderRadius = const BorderRadius.all(
+      Radius.circular(8.0),
+    ),
+    this.animationDuration = const Duration(milliseconds: 200),
+    this.animationCurve = Curves.ease,
+    this.isActive = false,
+  }) : super(key: key);
+
+  final EdgeInsets padding;
+
+  final TargetWidgetBuilder builder;
+
+  final VoidCallback? onPressed;
+
+  final ColorBuilder backgroundColorBuilder;
+
+  final BoxConstraints? constraints;
+
+  final BorderRadius borderRadius;
+
+  final Duration animationDuration;
+
+  final Curve animationCurve;
+
+  final bool isActive;
+
+  @override
+  State<StatefulWidget> createState() => _RawAdwTargetState();
+}
+
+class _RawAdwTargetState extends State<RawAdwTarget> {
+  late TargetStatus _status;
+
+  @override
+  void initState() {
+    super.initState();
+    _status = widget.isActive ? TargetStatus.active : TargetStatus.enabled;
+  }
+
+  @override
+  void didUpdateWidget(covariant RawAdwTarget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _status = widget.isActive ? TargetStatus.active : TargetStatus.enabled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _status = TargetStatus.hover),
+      onExit: (_) => setState(
+        () => _status =
+            widget.isActive ? TargetStatus.active : TargetStatus.enabled,
+      ),
+      child: GestureDetector(
+        onTap: widget.onPressed,
+        onTapDown: (_) => setState(() => _status = TargetStatus.tapDown),
+        onTapUp: (_) => setState(
+          () => _status =
+              widget.isActive ? TargetStatus.active : TargetStatus.enabled,
+        ),
+        child: AnimatedContainer(
+          padding: widget.padding,
+          constraints: widget.constraints,
+          duration: widget.animationDuration,
+          curve: widget.animationCurve,
+          decoration: BoxDecoration(
+            borderRadius: widget.borderRadius,
+            color: widget.backgroundColorBuilder(context, _status),
+          ),
+          child: widget.builder(context, _status),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/adw/raw_target.dart
+++ b/lib/src/widgets/adw/raw_target.dart
@@ -17,6 +17,8 @@ class RawAdwTarget extends StatefulWidget {
     this.borderRadius = const BorderRadius.all(
       Radius.circular(8.0),
     ),
+    this.border,
+    this.shape = BoxShape.rectangle,
     this.animationDuration = const Duration(milliseconds: 200),
     this.animationCurve = Curves.ease,
     this.isActive = false,
@@ -33,6 +35,10 @@ class RawAdwTarget extends StatefulWidget {
   final BoxConstraints? constraints;
 
   final BorderRadius borderRadius;
+
+  final BoxBorder? border;
+
+  final BoxShape shape;
 
   final Duration animationDuration;
 
@@ -81,6 +87,8 @@ class _RawAdwTargetState extends State<RawAdwTarget> {
           duration: widget.animationDuration,
           curve: widget.animationCurve,
           decoration: BoxDecoration(
+            border: widget.border,
+            shape: widget.shape,
             borderRadius: widget.borderRadius,
             color: widget.backgroundColorBuilder(context, _status),
           ),

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -1,12 +1,12 @@
 // All the widgets imported from libadwaita
 export 'adw/action_row.dart';
 export 'adw/avatar.dart';
+export 'adw/button.dart';
 export 'adw/combo_row.dart';
 export 'adw/clamp.dart';
 export 'adw/flap.dart';
 export 'adw/header_bar.dart';
 export 'adw/preferences_group.dart';
-export 'adw/raw_target.dart';
 export 'adw/view_switcher.dart';
 export 'adw/view_switcher_tab.dart';
 export 'adw/view_stack.dart';

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -6,6 +6,7 @@ export 'adw/clamp.dart';
 export 'adw/flap.dart';
 export 'adw/header_bar.dart';
 export 'adw/preferences_group.dart';
+export 'adw/raw_target.dart';
 export 'adw/view_switcher.dart';
 export 'adw/view_switcher_tab.dart';
 export 'adw/view_stack.dart';


### PR DESCRIPTION
This PR introduces a new widget `RawAdwTarget`. This widget could be useful when you want to build a button or any clickable widget: `AdwSidebarItem`, `AdwTextButton` etc.

- It handles its state internally (hover, enabled, active) and allows you to change its background color and child depending on the state.
- This is based on the work done on the `AdwHeaderButton` and various other widgets around the app.
- It allows to reuse common logic and system for this kind of situations.

Included in this PR is a rework on the `AdwHeaderButton` using this new widget, in order to illustrate how this new widget could be used.

Let me know what you think about this widget and its use in the app.