### PR TITLE
Fix scroll issues on example project

### DIFF
--- a/example/lib/pages/flap_page.dart
+++ b/example/lib/pages/flap_page.dart
@@ -2,34 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:libadwaita/libadwaita.dart';
 import 'package:multi_window/multi_window.dart';
 
-class FlapPage extends StatefulWidget {
+class FlapPage extends StatelessWidget {
   const FlapPage({Key? key}) : super(key: key);
-
-  @override
-  _FlapPageState createState() => _FlapPageState();
-}
-
-class _FlapPageState extends State<FlapPage> {
-  late ScrollController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: AdwClamp.scrollable(
         center: true,
-        controller: _controller,
         child: Column(
           children: [
             Text(

--- a/example/lib/pages/lists_page.dart
+++ b/example/lib/pages/lists_page.dart
@@ -1,33 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:libadwaita/libadwaita.dart';
 
-class ListsPage extends StatefulWidget {
+class ListsPage extends StatelessWidget {
   const ListsPage({Key? key}) : super(key: key);
-
-  @override
-  _ListsPageState createState() => _ListsPageState();
-}
-
-class _ListsPageState extends State<ListsPage> {
-  late ScrollController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return AdwClamp.scrollable(
       center: true,
-      controller: _controller,
       child: Column(
         children: [
           const Icon(

--- a/example/lib/pages/settings_page.dart
+++ b/example/lib/pages/settings_page.dart
@@ -1,33 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:libadwaita/libadwaita.dart';
 
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends StatelessWidget {
   const SettingsPage({Key? key}) : super(key: key);
-
-  @override
-  _SettingsPageState createState() => _SettingsPageState();
-}
-
-class _SettingsPageState extends State<SettingsPage> {
-  late ScrollController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return AdwClamp.scrollable(
       center: true,
-      controller: _controller,
       child: Column(
         children: [
           const AdwPreferencesGroup(

--- a/example/lib/pages/view_switcher_page.dart
+++ b/example/lib/pages/view_switcher_page.dart
@@ -2,34 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:libadwaita/libadwaita.dart';
 import 'package:multi_window/multi_window.dart';
 
-class ViewSwitcherPage extends StatefulWidget {
+class ViewSwitcherPage extends StatelessWidget {
   const ViewSwitcherPage({Key? key}) : super(key: key);
-
-  @override
-  _ViewSwitcherPageState createState() => _ViewSwitcherPageState();
-}
-
-class _ViewSwitcherPageState extends State<ViewSwitcherPage> {
-  late ScrollController _controller;
-
-  @override
-  void initState() {
-    super.initState();
-    _controller = ScrollController();
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: AdwClamp.scrollable(
         center: true,
-        controller: _controller,
         child: Column(
           children: [
             Text(

--- a/lib/src/widgets/adw/clamp.dart
+++ b/lib/src/widgets/adw/clamp.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 
-class AdwClamp extends StatelessWidget {
-  final bool isScrollable;
-  final ScrollController? controller;
-
+class AdwClamp extends StatefulWidget {
   const AdwClamp({
     Key? key,
     required this.child,
@@ -26,6 +23,8 @@ class AdwClamp extends StatelessWidget {
   })  : isScrollable = true,
         super(key: key);
 
+  final bool isScrollable;
+  final ScrollController? controller;
   final bool center;
   final Widget child;
   final double maximumSize;
@@ -33,24 +32,43 @@ class AdwClamp extends StatelessWidget {
   final EdgeInsets margin;
 
   @override
+  State<StatefulWidget> createState() => _AdwClampState();
+}
+
+class _AdwClampState extends State<AdwClamp> {
+  late ScrollController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    var container = Container(
-      constraints: BoxConstraints(maxWidth: maximumSize),
-      margin: margin,
-      padding: padding,
-      child: child,
+    final container = Container(
+      constraints: BoxConstraints(maxWidth: widget.maximumSize),
+      margin: widget.margin,
+      padding: widget.padding,
+      child: widget.child,
     );
 
-    var centered = center
+    final centered = widget.center
         ? Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [Center(child: container)],
           )
         : container;
 
-    return isScrollable
+    return widget.isScrollable
         ? SingleChildScrollView(
-            controller: controller,
+            controller: widget.controller ?? _controller,
             child: centered,
           )
         : centered;


### PR DESCRIPTION
Closes #37

I think the issues is that when no `ScrollController` instance is provided to the `AdwClamp.scroll` widget, the `SingleChildScrollView` will try to get the `DefaultScrollController` from the widget tree via the context.

That caused an issue because that `ScrollController` was already been used in another page of the `AdwViewStack` widget.

The solution is to provide a new `ScrollController` when no one is provided to the `AdwClamp` widget.