### PR TITLE
Add CI github action

### DIFF
--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,35 @@
+# This is a basic workflow to help you get started with Actions
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: 'stable'
+      - run: dart --version
+      - run: flutter --version
+      - run: flutter analyze

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,9 +1,11 @@
+---
 # This is a basic workflow to help you get started with Actions
 name: CI
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push or pull request
+  # events but only for the main branch
   push:
     branches: [main]
     paths-ignore:
@@ -33,3 +35,11 @@ jobs:
       - run: dart --version
       - run: flutter --version
       - run: flutter analyze
+      - name: Build (Linux)
+        run: |
+          sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev
+          flutter config --enable-linux-desktop
+          cd example
+          flutter create --platforms=linux .
+          flutter build linux
+        if: matrix.os == 'ubuntu-latest'

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -43,3 +43,19 @@ jobs:
           flutter create --platforms=linux .
           flutter build linux
         if: matrix.os == 'ubuntu-latest'
+      - name: Build (Mac)
+        run: |
+          flutter config --enable-macos-desktop
+          cd example
+          flutter create --platforms=macos .
+          flutter doctor
+          flutter build macos
+        if: matrix.os == 'macos-latest'
+      - name: Build (Windows)
+        run: |
+          flutter config --enable-windows-desktop
+          cd example
+          flutter create --platforms=windows .
+          flutter doctor
+          flutter build windows
+        if: matrix.os == 'windows-latest'

--- a/.github/workflow/lint.yml
+++ b/.github/workflow/lint.yml
@@ -1,0 +1,53 @@
+---
+#################################
+#################################
+## Super Linter GitHub Actions ##
+#################################
+#################################
+name: Lint Code Base
+
+#
+# Documentation:
+# https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+#
+
+#############################
+# Start the job on all push #
+#############################
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+###############
+# Set the Job #
+###############
+jobs:
+  build:
+    # Name the Job
+    name: Lint Code Base
+    # Set the agent to run on
+    runs-on: ubuntu-latest
+
+    ##################
+    # Load all steps #
+    ##################
+    steps:
+      ##########################
+      # Checkout the code base #
+      ##########################
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      ################################
+      # Run Linter against code base #
+      ################################
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflow/publish.yml
+++ b/.github/workflow/publish.yml
@@ -1,0 +1,21 @@
+name: Publish plugin
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Publish
+        uses: sakebook/actions-flutter-pub-publisher@v1.3.1
+        with:
+          credential: ${{ secrets.CREDENTIAL_JSON }}
+          flutter_package: false
+          skip_test: true
+          dry_run: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Libadwaita ❤️ Flutter
+# Libadwaita ❤️ Flutter
 
 ![CI](https://github.com/gtk-flutter/libadwaita/actions/workflows/ci.yml/badge.svg)
 [![GitHub Super-Linter](https://github.com/gtk-flutter/adwaita/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
@@ -13,54 +13,58 @@ Unofficial implementation of Libadwaita Widgets in Flutter.
 
 **NOTE:** For getting colors from gtk 3.0 theme use version [`<=0.9.8+1`](https://pub.dev/packages/gtk/versions/0.9.8+1)
 
-### Features
+## Features
 
 - Various Libadwaita widgets ported to flutter
 - Some new widgets are also available, Check example for more info
 - Compatible with [various packages](#additional-information)
 
-### Usage
+## Usage
 
 - This only provides widgets, for theming you should consider [adwaita](https://pub.dev/packages/adwaita) or [yaru](https://github.com/ubuntu/yaru.dart) package.
 - If you want custom titlebar then you can follow the steps for that on [`bitsdojo_window`](https://pub.dev/packages/bitsdojo_window) package.
 - Following Widgets are currently ported to flutter, for more info visit [libadwaita documentation](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/index.html#classes):
-    - [`AdwActionRow`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ActionRow.html)
-    - [`AdwClamp`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Clamp.html)
-    - [`AdwComboRow`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ComboRow.html)
-    - [`AdwFlap`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Flap.html)
-    - [`AdwHeaderBar`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.HeaderBar.html) - use `.minimal` for using it without [`window_decorations`](https://pub.dev/packages/window_decorations) package.
-    - `AdwHeaderButton` - A Header button to be used with `AdwHeaderBar*`
-    - `AdwPopupMenu` - A Popup Menu button
-    - [`AdwPreferencesGroup`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PreferencesGroup.html)
-    - `AdwScaffold`
-    - `AdwStackSidebar` - GtkStackSidebar renamed to match the flow
-    - `AdwSidebar` - To be used with `AdwStackSidebar` or `AdwFlap`
-    - `AdwTextButton`
-    - `AdwTextField`
-    - [`AdwViewStack`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewStack.html)
-    - [`AdwViewSwitcher`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewSwitcher.html)
-    - `AdwViewSwitcherTab` - Tabs for AdwViewSwitcher
+
+  - [`AdwActionRow`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ActionRow.html)
+  - [`AdwClamp`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Clamp.html)
+  - [`AdwComboRow`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ComboRow.html)
+  - [`AdwFlap`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.Flap.html)
+  - [`AdwHeaderBar`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.HeaderBar.html) - use `.minimal` for using it without [`window_decorations`](https://pub.dev/packages/window_decorations) package.
+  - `AdwHeaderButton` - A Header button to be used with `AdwHeaderBar*`
+  - `AdwPopupMenu` - A Popup Menu button
+  - [`AdwPreferencesGroup`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.PreferencesGroup.html)
+  - `AdwScaffold`
+  - `AdwStackSidebar` - GtkStackSidebar renamed to match the flow
+  - `AdwSidebar` - To be used with `AdwStackSidebar` or `AdwFlap`
+  - `AdwTextButton`
+  - `AdwTextField`
+  - [`AdwViewStack`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewStack.html)
+  - [`AdwViewSwitcher`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ViewSwitcher.html)
+  - `AdwViewSwitcherTab` - Tabs for AdwViewSwitcher
 
 See the example app in the `example` folder for more info.
 
-### Additional information
+## Additional information
 
 This package is dependent on
+
 - [adwaita](https://pub.dev/packages/adwaita) or [yaru](https://github.com/ubuntu/yaru.dart) - For theming
 - [`popover`](https://pub.dev/packages/popover) for `AdwPopupMenu`.
 - [`window_decorations`](https://pub.dev/packages/window_decorations) for Window Decorations (not needed if you use `AdwHeaderBarMinimal`)
 
 Optional packages to use with this package:
+
 - [`adwaita_icons`](https://pub.dev/packages/adwaita_icons) for Adwaita Icons
 - [`bitsdojo_window`](https://pub.dev/packages/bitsdojo_window) for better look and feel with custom AdwHeaderBar.bitsdojo
 - [`nativeshell`](https://pub.dev/packages/nativeshell) for better look and feel with custom AdwHeaderBar.nativeshell
 
 [Classic API Docs](https://pub.dev/documentation/libadwaita/latest/)
 
-### License
+## License
 
 `LGPL v3 / GNU LESSER GENERAL PUBLIC LICENSE v3`
 
 TLDR;
+
 - You are free to use [this](https://pub.dev/packages/libadwaita) package in whatever app you want,
 - If you improve the package then you should submit your patches / improvements to [this](https://github.com/prateekmedia/gtk-flutter) repository.

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Optional packages to use with this package:
 TLDR;
 
 - You are free to use [this](https://pub.dev/packages/libadwaita) package in whatever app you want,
-- If you improve the package then you should submit your patches / improvements to [this](https://github.com/prateekmedia/gtk-flutter) repository.
+- If you improve the package then you should submit your patches / improvements to [this](https://github.com/gtk-flutter/libadwaita) repository.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## Libadwaita ❤️ Flutter
 
 ![CI](https://github.com/gtk-flutter/libadwaita/actions/workflows/ci.yml/badge.svg)
+[![GitHub Super-Linter](https://github.com/gtk-flutter/adwaita/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+
 [![Pub.dev](https://img.shields.io/pub/v/libadwaita.svg)](https://pub.dev/packages/libadwaita)
 [![License](https://img.shields.io/github/license/gtk-flutter/libadwaita?color=indigo)](LICENSE)
 [![Maintainer](https://img.shields.io/badge/Maintainer-prateekmedia-informational)](https://github.com/prateekmedia)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## Libadwaita ❤️ Flutter
 
+![CI](https://github.com/gtk-flutter/libadwaita/actions/workflows/ci.yml/badge.svg)
 [![Pub.dev](https://img.shields.io/pub/v/libadwaita.svg)](https://pub.dev/packages/libadwaita)
 [![License](https://img.shields.io/github/license/gtk-flutter/libadwaita?color=indigo)](LICENSE)
 [![Maintainer](https://img.shields.io/badge/Maintainer-prateekmedia-informational)](https://github.com/prateekmedia)


### PR DESCRIPTION
This PR adds a GitHub action to run `flutter analyze` on push and PR to main for validation. There is no test in the package yet, so the CI doesn't run any test ;).

I have added a similar CI in `adwaita` and also another action called `main.yml` to automatically publish the package to pub.dev anytime a new release is published. Let me know if you'd like to set up something similar here,