### PR TITLE
View Switcher Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.0-rc.2
+## 1.0.0-rc.2
 
 **BREAKING**
 - `AdwHeaderBarMinimal` is now `AdwHeaderBar.minimal`
@@ -13,7 +13,7 @@
 - Update View Switcher theming
 - Remove Scroll errors from example app by improving `AdwClamp`
 
-# 1.0.0-rc.1
+## 1.0.0-rc.1
 
 - Added the following widgets:
   - `AdwScaffold`
@@ -26,7 +26,7 @@
 - Update `AdwActionRow` & `AdwStackSidebar`
 - Improve `AdwFlap`
 
-# 1.0.0-rc.0
+## 1.0.0-rc.0
 
 - Seperate libadwaita (Widgets) and adwaita (Colors)
 - Rename Every widget from GtkSomething to AdwSomething
@@ -34,8 +34,8 @@
 - Add `AdwPreferenceGroup` and `AdwActionRow` from libadwaita.
 - Add `AdwStackSidebar` which is basically `GtkStackSidebar`
 - `AdwHeaderBar` parameter's
-    - Replace leading with start
-    - Replace trailing with end
-    - Replace center with title
+  - Replace leading with start
+  - Replace trailing with end
+  - Replace center with title
 
 For older Changelog visit: https://pub.dev/packages/gtk/changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 ## 1.0.0-rc.2
 
-- Add `AdwComboRow`, `AdwAvatar`
-- Improve Headerbar and Header Button
-- Update Sidebar theming to look more closer to libadwaita one
+** BREAKING **
+- `AdwHeaderBarMinimal` is now `AdwHeaderBar.minimal`
+- The `start` and `end` parameter of `AdwHeaderBar` are now `List<Widget>`
+- `AdwTextButton` is now `AdwButton.flat`
+- The `height` and `expanded` properties of ViewSwitcher are now deprecated 
+
+** Changes **
+- Add `AdwComboRow`, `AdwAvatar`, `AdwButton`(.pill, .circular, .flat)
+- Improve Header Button
+- Update Sidebar Theming
+- Update View Switcher theming
 - Remove Scroll errors from example app by improving `AdwClamp`
-- Deprecate `AdwHeaderBarMinimal`, Now use `AdwHeaderBar.minimal`
 
 ## 1.0.0-rc.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## 1.0.0-rc.2
 
-** BREAKING **
+**BREAKING**
 - `AdwHeaderBarMinimal` is now `AdwHeaderBar.minimal`
-- The `start` and `end` parameter of `AdwHeaderBar` are now `List<Widget>`
+- The `start` and `end` parameter of `AdwHeaderBar` are now `List<Widget>` instead of `Widget`
 - `AdwTextButton` is now `AdwButton.flat`
 - The `height` and `expanded` properties of ViewSwitcher are now deprecated 
 
-** Changes **
-- Add `AdwComboRow`, `AdwAvatar`, `AdwButton`(.pill, .circular, .flat)
+**Other Changes**
+- Add `AdwComboRow`, `AdwAvatar`, `AdwButton`(`.pill`, `.circular`, `.flat`)
 - Improve Header Button
 - Update Sidebar Theming
 - Update View Switcher theming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 1.0.0-rc.2
+# 1.0.0-rc.2
 
 **BREAKING**
 - `AdwHeaderBarMinimal` is now `AdwHeaderBar.minimal`
 - The `start` and `end` parameter of `AdwHeaderBar` are now `List<Widget>` instead of `Widget`
 - `AdwTextButton` is now `AdwButton.flat`
-- The `height` and `expanded` properties of ViewSwitcher are now deprecated 
+- The `height` and `expanded` properties of ViewSwitcher are now deprecated
 
 **Other Changes**
 - Add `AdwComboRow`, `AdwAvatar`, `AdwButton`(`.pill`, `.circular`, `.flat`)
@@ -13,20 +13,20 @@
 - Update View Switcher theming
 - Remove Scroll errors from example app by improving `AdwClamp`
 
-## 1.0.0-rc.1
+# 1.0.0-rc.1
 
 - Added the following widgets:
-    - `AdwScaffold`
-    - `AdwTextField`
-    - `AdwTextButton`
-    - `AdwViewStack`
-    - `WindowResizeListener`
+  - `AdwScaffold`
+  - `AdwTextField`
+  - `AdwTextButton`
+  - `AdwViewStack`
+  - `WindowResizeListener`
 - Fix Window buttons null error
 - Update Example
 - Update `AdwActionRow` & `AdwStackSidebar`
 - Improve `AdwFlap`
 
-## 1.0.0-rc.0
+# 1.0.0-rc.0
 
 - Seperate libadwaita (Widgets) and adwaita (Colors)
 - Rename Every widget from GtkSomething to AdwSomething

--- a/example/lib/flap/flap_home_page.dart
+++ b/example/lib/flap/flap_home_page.dart
@@ -52,21 +52,19 @@ class _FlapHomePageState extends State<FlapHomePage> {
         AdwHeaderBar.bitsdojo(
           appWindow: appWindow,
           windowDecor: windowDecor,
-          start: Row(
-            children: [
-              Builder(builder: (context) {
-                return AdwHeaderButton(
-                  icon: const Icon(Icons.view_sidebar, size: 15),
-                  isActive: _flapController.isOpen,
-                  onPressed: () => _flapController.toggle(),
-                );
-              }),
-              AdwHeaderButton(
-                icon: const Icon(Icons.nightlight_round, size: 15),
-                onPressed: changeTheme,
-              ),
-            ],
-          ),
+          start: [
+            Builder(builder: (context) {
+              return AdwHeaderButton(
+                icon: const Icon(Icons.view_sidebar, size: 15),
+                isActive: _flapController.isOpen,
+                onPressed: () => _flapController.toggle(),
+              );
+            }),
+            AdwHeaderButton(
+              icon: const Icon(Icons.nightlight_round, size: 15),
+              onPressed: changeTheme,
+            ),
+          ],
           title: const Text("AdwFlap Demo"),
         ),
         Expanded(

--- a/example/lib/home_page.dart
+++ b/example/lib/home_page.dart
@@ -57,47 +57,43 @@ class _MyHomePageState extends State<MyHomePage> {
         AdwHeaderBar.bitsdojo(
           appWindow: appWindow,
           windowDecor: windowDecor,
-          start: Row(
-            children: [
-              Builder(
-                builder: (context) {
-                  return AdwHeaderButton(
-                    icon: const Icon(Icons.view_sidebar, size: 15),
-                    isActive: _flapController.isOpen,
-                    onPressed: () {
-                      _flapController.toggle();
-                    },
-                  );
-                },
-              ),
-              AdwHeaderButton(
-                icon: const Icon(Icons.nightlight_round, size: 15),
-                onPressed: changeTheme,
-              ),
-            ],
-          ),
+          start: [
+            Builder(
+              builder: (context) {
+                return AdwHeaderButton(
+                  icon: const Icon(Icons.view_sidebar, size: 15),
+                  isActive: _flapController.isOpen,
+                  onPressed: () {
+                    _flapController.toggle();
+                  },
+                );
+              },
+            ),
+            AdwHeaderButton(
+              icon: const Icon(Icons.nightlight_round, size: 15),
+              onPressed: changeTheme,
+            ),
+          ],
           title: const Text("Libadwaita Demo"),
-          end: Row(
-            children: [
-              AdwPopupMenu(
-                body: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    ListTile(
-                      onTap: () {
-                        counter.value = 0;
-                        Navigator.of(context).pop();
-                      },
-                      title: const Text(
-                        'Reset Counter',
-                        style: TextStyle(fontSize: 15),
-                      ),
+          end: [
+            AdwPopupMenu(
+              body: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListTile(
+                    onTap: () {
+                      counter.value = 0;
+                      Navigator.of(context).pop();
+                    },
+                    title: const Text(
+                      'Reset Counter',
+                      style: TextStyle(fontSize: 15),
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
         Expanded(
           child: AdwScaffold(

--- a/example/lib/view_switcher/view_switcher_demo.dart
+++ b/example/lib/view_switcher/view_switcher_demo.dart
@@ -3,8 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:adwaita/adwaita.dart';
 
 class ViewSwitcherDemo extends StatelessWidget {
-  final ValueNotifier<ThemeMode> themeNotifier =
-      ValueNotifier(ThemeMode.system);
+  final ValueNotifier<ThemeMode> themeNotifier = ValueNotifier(ThemeMode.light);
 
   ViewSwitcherDemo({Key? key}) : super(key: key);
 

--- a/example/lib/view_switcher/view_switcher_demo.dart
+++ b/example/lib/view_switcher/view_switcher_demo.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:adwaita/adwaita.dart';
 
 class ViewSwitcherDemo extends StatelessWidget {
-  final ValueNotifier<ThemeMode> themeNotifier = ValueNotifier(ThemeMode.light);
+  final ValueNotifier<ThemeMode> themeNotifier =
+      ValueNotifier(ThemeMode.system);
 
   ViewSwitcherDemo({Key? key}) : super(key: key);
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -172,6 +172,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:
@@ -302,7 +309,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/widgets/adw/header_bar.dart
+++ b/lib/src/widgets/adw/header_bar.dart
@@ -7,13 +7,13 @@ import 'package:libadwaita/libadwaita.dart';
 
 class AdwHeaderBar extends StatefulWidget {
   /// The leading widget for the headerbar
-  final Widget start;
+  final List<Widget> start;
 
   /// The center widget for the headerbar
   final Widget title;
 
   /// The trailing widget for the headerbar
-  final Widget end;
+  final List<Widget> end;
 
   final Widget? minimizeBtn;
 
@@ -49,9 +49,9 @@ class AdwHeaderBar extends StatefulWidget {
     dynamic themeType,
     this.onDoubleTap,
     this.onHeaderDrag,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -85,9 +85,9 @@ class AdwHeaderBar extends StatefulWidget {
     Key? key,
     this.onDoubleTap,
     this.onHeaderDrag,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -108,9 +108,9 @@ class AdwHeaderBar extends StatefulWidget {
 
     /// The appWindow object from bitsdojo_window package
     required appWindow,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -141,9 +141,9 @@ class AdwHeaderBar extends StatefulWidget {
 
     /// The appWindow object from bitsdojo_window package
     required appWindow,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -169,9 +169,9 @@ class AdwHeaderBar extends StatefulWidget {
 
     /// The Window.of(context) object from nativeshell package
     required window,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -194,9 +194,9 @@ class AdwHeaderBar extends StatefulWidget {
 
     /// The Window.of(context) object from nativeshell package
     required window,
-    this.start = const SizedBox(),
+    this.start = const [],
     this.title = const SizedBox(),
-    this.end = const SizedBox(),
+    this.end = const [],
     this.padding = const EdgeInsets.only(left: 3, right: 5),
     this.titlebarSpace = 4,
     this.height = 51,
@@ -292,14 +292,22 @@ class _AdwHeaderBarState extends State<AdwHeaderBar> {
                                 SizedBox(width: widget.titlebarSpace),
                               for (var i in sep[0].split(','))
                                 if (windowButtons[i] != null) windowButtons[i]!,
-                              widget.start,
+                              ...widget.start.map(
+                                (e) => Padding(
+                                    padding: const EdgeInsets.only(right: 5),
+                                    child: e),
+                              ),
                             ],
                           ),
                           middle: widget.title,
                           trailing: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              widget.end,
+                              ...widget.end.map(
+                                (e) => Padding(
+                                    padding: const EdgeInsets.only(left: 5),
+                                    child: e),
+                              ),
                               if (hasWindowControls &&
                                   sep[1].split(',').isNotEmpty)
                                 SizedBox(width: widget.titlebarSpace),

--- a/lib/src/widgets/adw/new/scaffold.dart
+++ b/lib/src/widgets/adw/new/scaffold.dart
@@ -10,13 +10,17 @@ class AdwScaffold extends StatefulWidget {
   /// Remove this when ViewSwitcher becomes adaptive
   final Widget? bottomNavigationBar;
 
-  const AdwScaffold({
+  AdwScaffold({
     Key? key,
     required this.body,
     this.flapController,
-    this.drawer,
+    Widget? drawer,
     this.bottomNavigationBar,
-  }) : super(key: key);
+  })  :
+
+        /// Use less width to match libadwaita
+        drawer = drawer != null ? SizedBox(width: 200, child: drawer) : null,
+        super(key: key);
 
   @override
   _AdwScaffoldState createState() => _AdwScaffoldState();

--- a/lib/src/widgets/adw/view_switcher.dart
+++ b/lib/src/widgets/adw/view_switcher.dart
@@ -4,9 +4,8 @@ import 'package:flutter/material.dart';
 class AdwViewSwitcher extends StatelessWidget {
   final List<ViewSwitcherData> tabs;
   final ValueChanged<int> onViewChanged;
-  final ViewSwitcherStyle style;
+  final ViewSwitcherStyle? style;
   final int currentIndex;
-  final bool expanded;
   final double height;
 
   const AdwViewSwitcher({
@@ -14,43 +13,33 @@ class AdwViewSwitcher extends StatelessWidget {
     required this.tabs,
     required this.onViewChanged,
     required this.currentIndex,
-    this.style = ViewSwitcherStyle.desktop,
+    this.style,
     this.height = 55,
-    bool? expanded,
-  })  : expanded =
-            expanded ?? (style == ViewSwitcherStyle.desktop ? false : true),
-        assert(tabs.length >= 2),
+    @Deprecated(
+      'This field is now ignored. '
+      'This feature was deprecated after v1.0.0-rc.2',
+    )
+        bool? expanded,
+  })  : assert(tabs.length >= 2),
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    ViewSwitcherStyle newStyle = style ??
+        (MediaQuery.of(context).size.width > 600
+            ? ViewSwitcherStyle.desktop
+            : ViewSwitcherStyle.mobile);
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         for (final tab in tabs.asMap().entries)
-          () {
-            var ctab = InkWell(
-              onTap:
-                  currentIndex != tab.key ? () => onViewChanged(tab.key) : null,
-              child: Container(
-                height: height,
-                decoration: BoxDecoration(
-                  color: tab.key == currentIndex
-                      ? Theme.of(context)
-                          .appBarTheme
-                          .backgroundColor
-                          ?.darken(0.05)
-                      : Colors.transparent,
-                ),
-                child: AdwViewSwitcherTab(
-                  data: tab.value,
-                  isSelected: tab.key == currentIndex,
-                  style: style,
-                ),
-              ),
-            );
-            return expanded ? Expanded(child: ctab) : ctab;
-          }()
+          AdwViewSwitcherTab(
+            data: tab.value,
+            isSelected: tab.key == currentIndex,
+            onSelected:
+                currentIndex != tab.key ? () => onViewChanged(tab.key) : () {},
+            style: newStyle,
+          )
       ],
     );
   }

--- a/lib/src/widgets/adw/view_switcher.dart
+++ b/lib/src/widgets/adw/view_switcher.dart
@@ -14,7 +14,8 @@ class AdwViewSwitcher extends StatelessWidget {
     required this.onViewChanged,
     required this.currentIndex,
     this.style,
-    this.height = 55,
+    @Deprecated('This parameter is no longer in use')
+        this.height = 55,
     @Deprecated(
       'This field is now ignored. '
       'This feature was deprecated after v1.0.0-rc.2',
@@ -25,22 +26,28 @@ class AdwViewSwitcher extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    ViewSwitcherStyle newStyle = style ??
-        (MediaQuery.of(context).size.width > 600
-            ? ViewSwitcherStyle.desktop
-            : ViewSwitcherStyle.mobile);
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (final tab in tabs.asMap().entries)
-          AdwViewSwitcherTab(
-            data: tab.value,
-            isSelected: tab.key == currentIndex,
-            onSelected:
-                currentIndex != tab.key ? () => onViewChanged(tab.key) : () {},
-            style: newStyle,
-          )
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final newStyle = style ??
+            (constraints.maxWidth > 600
+                ? ViewSwitcherStyle.desktop
+                : ViewSwitcherStyle.mobile);
+
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final tab in tabs.asMap().entries)
+              AdwViewSwitcherTab(
+                data: tab.value,
+                style: newStyle,
+                isSelected: tab.key == currentIndex,
+                onSelected: currentIndex != tab.key
+                    ? () => onViewChanged(tab.key)
+                    : null,
+              )
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/src/widgets/adw/view_switcher_tab.dart
+++ b/lib/src/widgets/adw/view_switcher_tab.dart
@@ -27,7 +27,7 @@ class AdwViewSwitcherTab extends StatelessWidget {
     return AdwButton.flat(
       constraints: isDesktop
           ? const BoxConstraints(minWidth: 120, maxHeight: 36)
-          : const BoxConstraints(minWidth: 100, maxHeight: 36),
+          : const BoxConstraints(minWidth: 75),
       margin:
           isDesktop ? const EdgeInsets.symmetric(vertical: 6) : EdgeInsets.zero,
       onPressed: onSelected,

--- a/lib/src/widgets/adw/view_switcher_tab.dart
+++ b/lib/src/widgets/adw/view_switcher_tab.dart
@@ -5,58 +5,57 @@ class AdwViewSwitcherTab extends StatelessWidget {
   final ViewSwitcherData data;
   final ViewSwitcherStyle style;
   final bool isSelected;
-  final VoidCallback onSelected;
+  final VoidCallback? onSelected;
 
   const AdwViewSwitcherTab({
     Key? key,
     required this.data,
-    required this.isSelected,
-    required this.onSelected,
     required this.style,
+    this.isSelected = false,
+    this.onSelected,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final icon = Icon(
-      data.icon,
-      size: 18,
-    );
-
-    bool isDesktop = style == ViewSwitcherStyle.desktop;
+    final isDesktop = style == ViewSwitcherStyle.desktop;
 
     return AdwButton.flat(
       constraints: isDesktop
-          ? const BoxConstraints(minWidth: 120, maxHeight: 36)
+          ? const BoxConstraints(minWidth: 120, minHeight: 34, maxHeight: 36)
           : const BoxConstraints(minWidth: 75),
-      margin:
-          isDesktop ? const EdgeInsets.symmetric(vertical: 6) : EdgeInsets.zero,
+      margin: isDesktop
+          ? const EdgeInsets.symmetric(vertical: 6).copyWith(right: 3)
+          : EdgeInsets.zero,
       onPressed: onSelected,
       isActive: isSelected,
-      child: _RowOrColumn(
+      textStyle: TextStyle(
+        fontSize: isDesktop ? null : 11,
+      ),
+      borderRadius: isDesktop
+          ? const BorderRadius.all(Radius.circular(6.0))
+          : BorderRadius.zero,
+      child: _AdwViewSwitcherTabLayout(
         isRow: isDesktop,
         children: [
-          if (data.icon != null) icon,
+          if (data.icon != null)
+            Icon(
+              data.icon,
+              size: 18,
+            ),
           if (data.icon != null && data.title != null)
             const SizedBox(width: 8, height: 2),
-          if (data.title != null)
-            Text(
-              data.title!,
-              style: Theme.of(context).textTheme.bodyText2?.copyWith(
-                    fontWeight: FontWeight.bold,
-                    fontSize: isDesktop ? 14 : 11,
-                  ),
-            ),
+          if (data.title != null) Text(data.title!),
         ],
       ),
     );
   }
 }
 
-class _RowOrColumn extends StatelessWidget {
+class _AdwViewSwitcherTabLayout extends StatelessWidget {
   final List<Widget> children;
   final bool isRow;
 
-  const _RowOrColumn({
+  const _AdwViewSwitcherTabLayout({
     Key? key,
     required this.isRow,
     required this.children,
@@ -65,10 +64,14 @@ class _RowOrColumn extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return isRow
-        ? Row(mainAxisAlignment: MainAxisAlignment.center, children: children)
+        ? Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: children,
+          )
         : Column(
             mainAxisSize: MainAxisSize.min,
             mainAxisAlignment: MainAxisAlignment.center,
-            children: children);
+            children: children,
+          );
   }
 }

--- a/lib/src/widgets/adw/view_switcher_tab.dart
+++ b/lib/src/widgets/adw/view_switcher_tab.dart
@@ -23,9 +23,8 @@ class AdwViewSwitcherTab extends StatelessWidget {
       constraints: isDesktop
           ? const BoxConstraints(minWidth: 120, minHeight: 34, maxHeight: 36)
           : const BoxConstraints(minWidth: 75),
-      margin: isDesktop
-          ? const EdgeInsets.symmetric(vertical: 6).copyWith(right: 3)
-          : EdgeInsets.zero,
+      margin:
+          isDesktop ? const EdgeInsets.fromLTRB(0, 6, 3, 6) : EdgeInsets.zero,
       onPressed: onSelected,
       isActive: isSelected,
       textStyle: TextStyle(

--- a/lib/src/widgets/adw/view_switcher_tab.dart
+++ b/lib/src/widgets/adw/view_switcher_tab.dart
@@ -5,11 +5,13 @@ class AdwViewSwitcherTab extends StatelessWidget {
   final ViewSwitcherData data;
   final ViewSwitcherStyle style;
   final bool isSelected;
+  final VoidCallback onSelected;
 
   const AdwViewSwitcherTab({
     Key? key,
     required this.data,
     required this.isSelected,
+    required this.onSelected,
     required this.style,
   }) : super(key: key);
 
@@ -20,44 +22,53 @@ class AdwViewSwitcherTab extends StatelessWidget {
       size: 18,
     );
 
-    return style == ViewSwitcherStyle.desktop
-        ? Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24.0),
-            child: Row(
-              children: [
-                if (data.icon != null) icon,
-                if (data.icon != null && data.title != null)
-                  const SizedBox(width: 8),
-                if (data.title != null)
-                  Text(
-                    data.title!,
-                    style: Theme.of(context).textTheme.bodyText2?.copyWith(
-                          fontWeight:
-                              isSelected ? FontWeight.bold : FontWeight.normal,
-                        ),
+    bool isDesktop = style == ViewSwitcherStyle.desktop;
+
+    return AdwButton.flat(
+      constraints: isDesktop
+          ? const BoxConstraints(minWidth: 120, maxHeight: 36)
+          : const BoxConstraints(minWidth: 100, maxHeight: 36),
+      margin:
+          isDesktop ? const EdgeInsets.symmetric(vertical: 6) : EdgeInsets.zero,
+      onPressed: onSelected,
+      isActive: isSelected,
+      child: _RowOrColumn(
+        isRow: isDesktop,
+        children: [
+          if (data.icon != null) icon,
+          if (data.icon != null && data.title != null)
+            const SizedBox(width: 8, height: 2),
+          if (data.title != null)
+            Text(
+              data.title!,
+              style: Theme.of(context).textTheme.bodyText2?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    fontSize: isDesktop ? 14 : 11,
                   ),
-              ],
             ),
-          )
-        : Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 21.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                if (data.icon != null) icon,
-                if (data.icon != null && data.title != null)
-                  const SizedBox(height: 2),
-                if (data.title != null)
-                  Text(
-                    data.title!,
-                    style: Theme.of(context).textTheme.bodyText2?.copyWith(
-                          fontSize: 12,
-                          fontWeight:
-                              isSelected ? FontWeight.bold : FontWeight.normal,
-                        ),
-                  ),
-              ],
-            ),
-          );
+        ],
+      ),
+    );
+  }
+}
+
+class _RowOrColumn extends StatelessWidget {
+  final List<Widget> children;
+  final bool isRow;
+
+  const _RowOrColumn({
+    Key? key,
+    required this.isRow,
+    required this.children,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return isRow
+        ? Row(mainAxisAlignment: MainAxisAlignment.center, children: children)
+        : Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: children);
   }
 }


### PR DESCRIPTION
- Use `AdwButton.flat` as base for View switcher tab
- Looks almost similar to the libadwaita one

View Switcher:
![View Switcher](https://user-images.githubusercontent.com/41370460/148680018-f9bc5a64-0044-48dd-b048-cf59bd0ad47a.png)

View Switcher Collapsed:
![View Switcher collapased](https://user-images.githubusercontent.com/41370460/148680049-29bf0aee-6316-4b81-b8c8-066bd172f04d.png)

Any feedback or code suggestion is welcome.