### PR TITLE
Remove blur from GtkPopupMenu

### DIFF
--- a/lib/src/widgets/gtk/popup_menu.dart
+++ b/lib/src/widgets/gtk/popup_menu.dart
@@ -44,12 +44,6 @@ class _GtkPopupMenuState extends State<GtkPopupMenu> {
         showPopover(
           context: context,
           arrowHeight: 14,
-          shadow: [
-            BoxShadow(
-              color: context.borderColor,
-              blurRadius: 6,
-            ),
-          ],
           barrierColor: Colors.transparent,
           bodyBuilder: (_) => Padding(
             padding: const EdgeInsets.all(4),


### PR DESCRIPTION
Fixes #75 

I'm not sure the original reason for adding blur so this may be the wrong approach, however removing it fixes the issues with dark mode, while remaining correct in light mode.

Comparison screenshots below.

***Before***
![before-light](https://user-images.githubusercontent.com/88255595/187224497-5f4fe198-685c-4eb9-907a-5f39fff08c8a.png)
![before-dark](https://user-images.githubusercontent.com/88255595/187224501-1f548b29-3de6-4aef-a789-016ad537f9cc.png)

***After***
![after-light](https://user-images.githubusercontent.com/88255595/187224646-f734895e-134f-467a-82f3-538e4647dac8.png)
![after-dark](https://user-images.githubusercontent.com/88255595/187224650-a759ea30-6a83-43eb-a175-770f41485cbb.png)


***Gnome Workbench***
![vlcsnap-2022-08-29-15h20m54s326](https://user-images.githubusercontent.com/88255595/187224825-6b38cc64-2c16-4b56-ad6c-48db89f740b6.png)
