### PR TITLE
Remove usage of private types in public API

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,6 @@ include: package:very_good_analysis/analysis_options.yaml
 linter:
   rules:
     public_member_api_docs: false
-    library_private_types_in_public_api: false
     avoid_setters_without_getters: false
 
 # Additional information about this file can be found at

--- a/lib/src/animations/slide_hide.dart
+++ b/lib/src/animations/slide_hide.dart
@@ -13,7 +13,7 @@ class SlideHide extends StatefulWidget {
   final double width;
 
   @override
-  _SlideHideState createState() => _SlideHideState();
+  State<SlideHide> createState() => _SlideHideState();
 }
 
 class _SlideHideState extends State<SlideHide>

--- a/lib/src/internal/window_resize_listener.dart
+++ b/lib/src/internal/window_resize_listener.dart
@@ -11,7 +11,7 @@ class WindowResizeListener extends StatefulWidget {
   final Widget child;
 
   @override
-  _WindowResizeListenerState createState() => _WindowResizeListenerState();
+  State<WindowResizeListener> createState() => _WindowResizeListenerState();
 }
 
 class _WindowResizeListenerState extends State<WindowResizeListener>

--- a/lib/src/widgets/adw/flap.dart
+++ b/lib/src/widgets/adw/flap.dart
@@ -77,7 +77,7 @@ class AdwFlap extends StatefulWidget {
   final FlapController? controller;
 
   @override
-  _AdwFlapState createState() => _AdwFlapState();
+  State<AdwFlap> createState() => _AdwFlapState();
 }
 
 class _AdwFlapState extends State<AdwFlap> {

--- a/lib/src/widgets/adw/new/scaffold.dart
+++ b/lib/src/widgets/adw/new/scaffold.dart
@@ -46,7 +46,7 @@ class AdwScaffold extends StatefulWidget {
   final double? viewSwitcherConstraint;
 
   @override
-  _AdwScaffoldState createState() => _AdwScaffoldState();
+  State<AdwScaffold> createState() => _AdwScaffoldState();
 }
 
 class _AdwScaffoldState extends State<AdwScaffold> {

--- a/lib/src/widgets/adw/view_stack.dart
+++ b/lib/src/widgets/adw/view_stack.dart
@@ -19,7 +19,7 @@ class AdwViewStack extends StatefulWidget {
   final Duration animationDuration;
 
   @override
-  _AdwViewStackState createState() => _AdwViewStackState();
+  State<AdwViewStack> createState() => _AdwViewStackState();
 }
 
 class _AdwViewStackState extends State<AdwViewStack>

--- a/lib/src/widgets/gtk/stack_sidebar.dart
+++ b/lib/src/widgets/gtk/stack_sidebar.dart
@@ -48,7 +48,7 @@ class GtkStackSidebar extends StatefulWidget {
   final Function(int? contentIndex, Widget content)? fullContentBuilder;
 
   @override
-  _GtkStackSidebarState createState() => _GtkStackSidebarState();
+  State<GtkStackSidebar> createState() => _GtkStackSidebarState();
 }
 
 class _GtkStackSidebarState extends State<GtkStackSidebar> {


### PR DESCRIPTION
A very minor change to avoid exposing private types in the public API, as suggested by the linting rule that currently is being ignored.