### PR TITLE
fix: header_bar.dart does a platform check prior to checking kIsWeb

### DIFF
--- a/lib/src/widgets/adw/header_bar.dart
+++ b/lib/src/widgets/adw/header_bar.dart
@@ -147,7 +147,9 @@ class _AdwHeaderBarState extends State<AdwHeaderBar> {
           );
       }
 
-      if (Platform.isMacOS) {
+      if (kIsWeb) {
+        return;
+      } else if (Platform.isMacOS) {
         updateSep('close,minimize,maximize:');
       } else if (Platform.isLinux) {
         final schema = GSettings('org.gnome.desktop.wm.preferences');


### PR DESCRIPTION
Due to how Platform checks are implemented in Flutter, attempting to check the system Platform from the context of a web application causes exceptions/crashes. 

To fix this, we just need to check if kIsWeb prior to doing checks with Platform.isFoo()